### PR TITLE
Use ISO-8601 dates

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', function () {
                   #${build.number}<i class="material-icons left">cloud_download</i>
                   </a></td>
                   <td data-build-id="${build.number}">${changes}</td>
-                  <td>${new Date(build.timestamp).toLocaleDateString({year: "numeric", month: "numeric", day: "numeric"})}</td>
+                  <td>${new Date(build.timestamp).toISOString().split('T')[0]}</td>
                 </tr>`;
             });
 


### PR DESCRIPTION
Being British, I was at first a little confused with the dates on the website. Using ISO-8601 will easily allow people to recognise the date.