### PR TITLE
Correct path to gulp executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "private": true,
     "scripts": {
-        "build": "node_modules/gulp/node_modules/.bin/gulp"
+        "build": "node_modules/.bin/gulp"
     },
     "devDependencies": {
         "gulp": "4.0.0",


### PR DESCRIPTION
Seems like before it was using gulp's own gulp dependency?