### PR TITLE
Add javadocs page

### DIFF
--- a/src/css/javadocs.scss
+++ b/src/css/javadocs.scss
@@ -1,0 +1,33 @@
+.builds-table td:last-child, .builds-table th:last-child {
+  width: max-content;
+}
+.download-desc {
+  padding: 10px;
+}
+.jenkins-btn {
+  display: block;
+  margin: 0 auto;
+}
+.commit-hash, .commit-hash a {
+  font-size: 12px;
+  font-family: monospace !important;
+}
+
+#downloads-tabs {
+  display: flex;
+
+  .tab {
+    flex-grow: 1;
+  }
+}
+
+a.btn {
+  margin-top: 20px;
+}
+
+@media only screen and (max-width: 601px) {
+  /* Hidden indicator due to #7, Materialize JS modification may be required to work as intended */
+  #downloads-tabs .indicator {
+    display: none;
+  }
+}

--- a/src/javadocs.twig
+++ b/src/javadocs.twig
@@ -1,0 +1,40 @@
+<!doctype html>
+{% extends 'partial/layout.twig' %}
+{% set page = 'javadocs' %}
+{% set title = 'Javadocs – PaperMC' %}
+{% block styles %}
+  <link type="text/css" rel="stylesheet" href="{{ urls['css/javadocs.css'] }}" media="screen, projection"/>
+{% endblock %}
+{% block content %}
+  {# Main Scrollable Content #}
+  <main class="container">
+    <h1>Javadocs</h1>
+    <span>You can view the javadocs for specific versions of Paper or Waterfall below.</span>
+    <div id="paper" class="row">
+	  <h3>Paper</h3>
+	  <p>Javadocs for Paper can be found down below.</p>
+	  <div>
+	    <a href="https://papermc.io/javadocs/paper/1.14/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>1.14 javadocs</a>
+	  </div>
+	  <div>
+	    <a href="https://papermc.io/javadocs/paper/1.13/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>1.13 javadocs</a>
+	  </div>
+	  <div>
+	    <a href="https://papermc.io/javadocs/paper/1.12/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>1.12 javadocs</a>
+      </div>
+	</div>
+	<div id="waterfall" class="row">
+	  <h3>Waterfall</h3>
+	  <p>Javadocs for Waterfall can be found down below.</p>
+	  <div>
+	    <a href="https://papermc.io/javadocs/waterfall/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>Javadocs</a>
+	  </div>
+	</div>
+  </main>
+{% endblock %}
+{% block footer %}
+{% endblock %}


### PR DESCRIPTION
Someone requested in the PaperMC Discord guild a nicer looking javadocs page than the one we currently have (which is just an index page with links to folders), so I thought I'd throw something together. I'm not very familiar with web development or design, so please point out any mistakes.

Here's a screenshot on how the page with these changes looks:
![image](https://user-images.githubusercontent.com/12550728/64912973-c46a8880-d737-11e9-9c0b-e752874b19db.png)

I tried to keep a similar style to those of the other pages. It's quite simple, because a) I don't know what else I would put there and b) I wanted to keep the ease of access similar to how it currently works (you just click on the index link and you're there). Feel free to request additions, changes, etc.

I'm not entirely sure which versions you actually want linked. I added 1.12-1.14 because those were also available on the old page, but perhaps you don't want 1.12 since support has dropped for that?

I didn't change anything in terms of linking, I'm assuming that the added javadocs.twig file will just overwrite the index page that is currently there (couldn't find anything related to that, so I'm assuming that just happens automatically?), but let me know if that is not the case.

I personally don't mind the current page either, so feel free to just close this if you want to keep it like it currently is.