### PR TITLE
Added Discord button to the community page

### DIFF
--- a/src/community.twig
+++ b/src/community.twig
@@ -39,6 +39,8 @@
           <div class="container">
             <h1>Discord</h1>
             <span>Discord is a popular option for many gamers to communicate with each other. We have a Discord community server that anyone can join.</span>
+            <br><br>
+            <a class="downloads-button white grey-text text-darken-4 btn nav-btn waves-effect" href="https://discord.gg/papermc"><i class="material-icons left">chat</i> Discord</a>
           </div>
         </div>
         <div class="container">

--- a/src/css/community.scss
+++ b/src/css/community.scss
@@ -7,7 +7,7 @@ main > .container {
 #discord-container {
   width: 100%;
   color: white;
-  height: 570px;
+  height: 640px;
   background-color: #212121;
 
   iframe {
@@ -20,7 +20,7 @@ main > .container {
     display: block;
   }
   .main {
-    height: 300px;
+    height: 370px;
     background: url('../images/discord-background.svg') repeat;
     background-color: #6881D8;
     background-size: 150px;


### PR DESCRIPTION
This change adds a Discord button to the Community page, as there isn't currently a clear way to join the Discord server.

In theory, there should be a way to join the server from within the embedded Discord widget. However, at the present time, that doesn't appear to be the case.

With the added button, the Discord section of the Community page looks as follows:
![Updated Discord Section](
http://www.userfolio.com/uploads/Screen-Shot-2020-08-06-14-52-28.47.png)