### PR TITLE
Added pronouns to ZTIs

### DIFF
--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -172,7 +172,16 @@
         <ul class="bullet-list">
           <li>Racial slurs or racist speech</li>
           <li>Sexist slurs or sexist speech</li>
-          <li>Homophobic or transphobic slurs or speech</li>
+          <li>
+	    Homophobic or transphobic slurs or speech
+	    <ul>
+	      <li>
+	        A user's desired pronouns should be respected if they are mentioned in the user's nickname. For example,
+		if someone includes something to the general affect of `(he/him)`, `(she/her)`, `(they/them)`, or another set 
+		of pronouns, including neopronouns, please use them when addressing the person in the third-person point-of-view.
+	      </li>
+	    </ul>
+	  </li>
           <li>
             Ableist slurs or speech &mdash; there's confusion around this term, so to help clarify:
             <ul>


### PR DESCRIPTION
A few unfortunately somewhat common occurrences in the community recently have included some people questioning the use of pronouns in another user's username, ridiculing the concept of putting pronouns in one's name, or putting fake pronouns in one's name (i.e. `(that/it)`). In some cases, the fake pronouns are meant sarcastically or as a joke, but it does not feel like a joke to the people being ridiculed for it. To help combat this, I am proposing adding a section to the CG regarding respecting people's desired pronouns. 

This is not: a blanket statement requiring everybody to be hyperaware of desired pronouns
This is: a statement requiring clearly visible pronouns to be respected