### PR TITLE
Add widths to download tables

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -133,9 +133,9 @@ function load(id) {
             <table class="builds-table">
               <thead>
                 <tr>
-                  <th>Build</th>
-                  <th>Changes</th>
-                  <th>Date</th>
+                  <th width="14%">Build</th>
+                  <th width="76%">Changes</th>
+                  <th width="10%">Date</th>
                 </tr>
               </thead>
 


### PR DESCRIPTION
Currently when browsing the downloads page on the papermc.io website, when moving between the Paper, Waterfall and Travertine tabs, the column widths of the download table changes on each section. This makes it so that the text shifts around when doing so and is in my opinion visually distracting (although it's super minor). This occurs because table widths are automatically determined based on the contents of the overall table; since the content differs between each tab, the column widths are different.

This pull request specifies a percentage-based width for each column on each download tab. This forces the column to adhere to this width and are now the same on each tab. In turn, all text stays in the same position when moving between tabs. Testing this locally, this works fine on desktops and also on mobile devices, both in portrait and landscape mode.

The widths specified are approximations of the current column widths on the Paper download section. The build column has enough space to fit properly, even if the build numbers would go into the four digits at some point. The changes column is the largest column and has plenty of space to show an entire sentence. If more space is needed, it will just go on the next line like it would also do currently. The date column is the smallest, but the text fits in the column and has room for an extra digit or two.

Other than the fixed widths, no other changes have been made.