### PR TITLE
Replace "Learn about performance" with "Read our FAQ"

### DIFF
--- a/src/index.twig
+++ b/src/index.twig
@@ -25,8 +25,8 @@
           <p>
             Paper contains numerous improvements and optimizations resulting in a significant improvement in performance. Paper also includes the next version of Timings, enabling you to quickly find out what's slowing down your server.
           </p>
-          <a href="https://paper.readthedocs.io/" class="waves-effect waves-light btn light-blue darken-2">
-            <i class="material-icons left">archive</i>Learn about Performance</a>
+          <a href="https://paper.readthedocs.io/en/latest/about/faq.html" class="waves-effect waves-light btn light-blue darken-2">
+            <i class="material-icons left">archive</i>Read our FAQ</a>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
"Learn about the performance" links to our documentation, which makes no sense at all. Linking to our FAQ makes more sense imo