### PR TITLE
move travertine to legacy page

### DIFF
--- a/src/css/legacy.scss
+++ b/src/css/legacy.scss
@@ -1,0 +1,17 @@
+#legacy-tabs {
+    display: flex;
+  
+    .tab {
+      flex-grow: 1;
+    }
+}
+
+.download-desc {
+    padding: 10px;
+}
+
+i.benefit-icon {
+    text-align: center;
+    display: block;
+    font-size: 10rem;
+}

--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -17,15 +17,6 @@ const downloads = {
         "desc": "Our fork of the BungeeCord software, with improved Forge support and more features.",
         "limit": 10,
         "cache": null,
-    },
-    "Travertine": {
-        "title": "Travertine",
-        "api_endpoint": "travertine",
-        "api_version": "1.16",
-        "github": "PaperMC/Travertine",
-        "desc": "Waterfall, with additional support for Minecraft 1.7.10.",
-        "limit": 10,
-        "cache": null,
     }
 };
 

--- a/src/legacy.twig
+++ b/src/legacy.twig
@@ -1,18 +1,18 @@
 <!doctype html>
 {% extends 'partial/layout.twig' %}
 {% set page = 'legacy' %}
-{% set title = 'Legacy – The High Performance Fork' %}
+{% set title = 'Legacy Downloads – PaperMC' %}
 {% block styles %}
-  <link type="text/css" rel="stylesheet" href="{{ urls['css/index.css'] }}" media="screen, projection"/>
+  <link type="text/css" rel="stylesheet" href="{{ urls['css/legacy.css'] }}" media="screen, projection"/>
 {% endblock %}
 {% block content %}
   {# Main Scrollable Content #}
-  <main>
-  <div class="jumbotron white-text">
-    <h1>Legacy Downloads</h1>
-    <p><strong>These are here purely for informational reasons. No support is given to these whatsoever.</strong></p>
-  </div>
-      <div id="content" class="row"></div>
+  <main class="container">
+    <div class="jumbotron white-text">
+      <h1>Legacy Downloads</h1>
+      <p><strong>These are here purely for informational reasons. No support is given to these whatsoever.</strong></p>
+    </div>
+    <div id="content" class="row"></div>
   </main>
 {% endblock %}
 {% block footer %}


### PR DESCRIPTION
As Travertine has been discontinued as announced in Discord, this PR removes it from the downloads page.

(Going along with https://github.com/PaperMC/PaperDocs/pull/63)