### PR TITLE
[For later] Update downloads page to target 1.17.1

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -3,7 +3,6 @@ const downloads = {
         "title": "Paper 1.17.1",
         "api_endpoint": "paper",
         "api_version": "1.17",
-        "jenkins": "Paper-1.17",
         "github": "PaperMC/Paper",
         "desc": "Active development for the current Minecraft version.",
         "limit": 10,

--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -1,9 +1,9 @@
 const downloads = {
-    "Paper-1.16": {
-        "title": "Paper 1.16.5",
+    "Paper-1.17": {
+        "title": "Paper 1.17.1",
         "api_endpoint": "paper",
-        "api_version": "1.16",
-        "jenkins": "Paper-1.16",
+        "api_version": "1.17",
+        "jenkins": "Paper-1.17",
         "github": "PaperMC/Paper",
         "desc": "Active development for the current Minecraft version.",
         "limit": 10,


### PR DESCRIPTION
When the time comes, this PR updates the downloads page to point at 1.17. However, it is gonna conflict with #88 unless edited as I did these at the same time.

edit: o wait if #88 merges then i can edit it myself nvm