### PR TITLE
Use API download artifact name instead of guessing

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -118,7 +118,7 @@ function load(id) {
         }
 
         rows += `<tr>
-              <td><a href="/api/v2/projects/${downloads[id].api_endpoint}/versions/${build.version}/builds/${build.build}/downloads/${downloads[id].api_endpoint}-${build.version}-${build.build}.jar"
+              <td><a href="/api/v2/projects/${downloads[id].api_endpoint}/versions/${build.version}/builds/${build.build}/downloads/${build.downloads.application.name}"
               class="btn waves-light waves-effect grey darken-4">
               #${build.build}<i class="material-icons left">cloud_download</i>
               </a></td>


### PR DESCRIPTION
Previously the webpage would guess the name of the paperclip artifact
that a user downloads by combining the version and build number. While
this guess, at least as of right now, still works, there is no API
contract to ensure it keeps on working this way.

This commit uses the already fetched artifact name from the API when
building the href instead of guessing.