### PR TITLE
ignore GH Sponsors in OC Sponsors

### DIFF
--- a/.github/actions/update-sponsors/action.js
+++ b/.github/actions/update-sponsors/action.js
@@ -16,7 +16,7 @@ async function main() {
 
     let listEntries = "";
     let count = 0;
-    ocData.collective.contributors.nodes.forEach(node => {
+    ocData.collective.contributors.nodes.filter(node => node.name !== "Github Sponsors").forEach(node => {
         listEntries += createListEntry(node.name, node.image);
         count++;
     });


### PR DESCRIPTION
GH Sponsors are already shown; this is double counting. Users don't seem to have an ID or anything, so just the name is used.