### PR TITLE
Update color scheme for downloads and legacy downloads

### DIFF
--- a/src/css/downloads.scss
+++ b/src/css/downloads.scss
@@ -20,6 +20,10 @@
   }
 }
 
+table.striped > tbody > tr:nth-child(2n+1) {
+  background-color: #1e2021;
+}
+
 @media only screen and (max-width: 601px) {
   /* Hidden indicator due to #7, Materialize JS modification may be required to work as intended */
   #downloads-tabs .indicator {

--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -119,7 +119,7 @@ function load(id) {
 
         rows += `<tr>
               <td><a href="/api/v2/projects/${downloads[id].api_endpoint}/versions/${build.version}/builds/${build.build}/downloads/${build.downloads.application.name}"
-              class="btn waves-light waves-effect grey darken-4">
+              class="waves-effect waves-light btn light-blue darken-2">
               #${build.build}<i class="material-icons left">cloud_download</i>
               </a></td>
               <td data-build-id="${build.build}">${changes}</td>
@@ -129,7 +129,7 @@ function load(id) {
 
     container.innerHTML = `
           <div class="download-desc">${downloads[id].desc}</div>
-            <table class="builds-table">
+            <table class="builds-table striped">
               <thead>
                 <tr>
                   <th width="14%">Build</th>
@@ -145,7 +145,7 @@ function load(id) {
             `;
 
     if (json.builds.length > downloads[id].limit) {
-        container.innerHTML += `<a class="wide-btn btn light-blue darken-2 waves-effect waves-light" onclick="loadMore('${id}')">More</a><br>`;
+        container.innerHTML += `<a class="wide-btn btn light-blue darken-2 waves-effect waves-light white-text" onclick="loadMore('${id}')">More</a><br>`;
     }
 
     if (downloads[id].api_endpoint === "paper") {

--- a/src/js/legacy.js
+++ b/src/js/legacy.js
@@ -161,7 +161,7 @@ async function load(id, version, build, name) {
       <div class="col s12 l9">
         <h4>${name ? name : version}</h4>
         <p><strong>This build is purely for accessibility. By clicking the download button, you acknowledge that no support will be provided whatsoever.</strong></p>
-        <a id="${id}-${version}-${build}" href="https://papermc.io/api/v2/projects/${downloads[id].api_endpoint}/versions/${version}/builds/${build}/downloads/${json.downloads.application.name}" class="waves-effect waves-light btn light-blue darken-2">Download Anyway</a>
+        <a id="${id}-${version}-${build}" href="https://papermc.io/api/v2/projects/${downloads[id].api_endpoint}/versions/${version}/builds/${build}/downloads/${json.downloads.application.name}" class="waves-effect waves-light btn red darken-2">Download Anyway</a>
       </div>
     </div>`;
   }


### PR DESCRIPTION
Update the color scheme for the downloads page to match the rest of the homepage
![grafik](https://user-images.githubusercontent.com/21148213/135753362-657b337c-98e2-4c03-bab1-c2edb6175770.png)

Make legacy downloads red as an attempt to scare people away
![grafik](https://user-images.githubusercontent.com/21148213/135753364-93b3da69-d43f-41d9-a89a-8766d74facc6.png)
