### PR TITLE
Move 1.16.5 over to the legacy page

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -8,15 +8,6 @@ const downloads = {
         "limit": 10,
         "cache": null,
     },
-    "Paper-1.16": {
-        "title": "Paper 1.16.5",
-        "api_endpoint": "paper",
-        "api_version": "1.16",
-        "github": "PaperMC/Paper",
-        "desc": "Support branch for 1.16.",
-        "limit": 10,
-        "cache": null,
-    },
     "Waterfall": {
         "title": "Waterfall",
         "api_endpoint": "waterfall",

--- a/src/js/legacy.js
+++ b/src/js/legacy.js
@@ -5,6 +5,10 @@ const downloads = {
       "api_endpoint": "paper",
       "versions": [
         {
+          "version": "1.16.5",
+          "build": "790"
+        },
+        {
           "version": "1.15.2",
           "build": "391"
         },


### PR DESCRIPTION
Probably pending other stuff we wanna do, but, 1.17 has been stable for a good few months now, especially with the tuinity merge and the fact that 1.16 has been on extended support for a while now, I think it's time