### PR TITLE
Update community guidelines to include other communication methods

### DIFF
--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -159,7 +159,7 @@
         </ol>
         <p>
           If someone is violating those feel free to use the <code>@mods</code> ping on Discord to notify the moderation team.
-          You can also contact the team privately using the <code>/modmail</code> command or sending a direct message to our bot <code>Pencil</code>, however this
+          You can also contact the team privately using the <code>/modmail</code> command or sending a direct message to our bot <code>Pencil#7974 (811281085723705395)</code>, however this
           does not alert us in the same way that the <code>@mods</code> ping does, so don't use it for time sensitive issues.
         </p>
       </div>


### PR DESCRIPTION
You can also use /modmail or DM pencil to send us a message (has been a function for a while now!)
However, this does not ping us like the mods-Ping, it just puts your message in an internal channel, so we might not see it as quickly as a mods ping.