### PR TITLE
Containerize the site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# vim: ft=gitignore
+# Ignore everything by default
+*
+# Whitelist what we want
+!src/
+!yarn.lock
+!package.json
+!gulpfile.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:17.0.1-alpine3.13 as builder
+WORKDIR /usr/src/app
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . ./
+RUN yarn build
+
+FROM nginx:1.12-alpine
+COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  website:
+    build: .
+    image: papermc.io:latest
+    ports: 
+      - 80:80


### PR DESCRIPTION
Takes about 20 seconds to build from scratch, with BuildKit enabled.

Feel free to drop docker-compose - not sure if it's useful.