### PR TITLE
Also resize icons on the sponsors page

### DIFF
--- a/src/community.twig
+++ b/src/community.twig
@@ -16,9 +16,9 @@
 
 	<div class="container">
 	  {# Guidelines #}
-	  <div id="guideline-container" class="community-platform valign-table">
+	  <div id="guideline-container" class="community-platform valign-table fancy-container">
 	    <div class="row container">
-          <div class="col l2 s12">
+          <div class="col l2 s12 icon-container">
 		    <i class="material-icons icon-large">gavel</i>
           </div>
           <div class="col l10 s12">
@@ -26,15 +26,15 @@
 			<p>
 			  The rules to our community, please read them before participating.
 			  <br><br>
-			  <a class="downloads-button white grey-text text-darken-4 btn nav-btn waves-effect" href="community-guidelines"><i class="material-icons left">gavel</i>Community Guidelines</a>
+			  <a class="downloads-button white grey-text text-darken-4 btn nav-btn waves-effect" href="/community-guidelines"><i class="material-icons left">gavel</i>Community Guidelines</a>
 			</p>
 		  </div>
 	    </div>
 	  </div>
       {# Forum #}
-      <div id="forum-container" class="community-platform valign-table">
+      <div id="forum-container" class="community-platform valign-table fancy-container">
         <div class="row container">
-          <div class="col l2 s12">
+          <div class="col l2 s12 icon-container">
             <i class="material-icons icon-large">forum</i>
           </div>
           <div class="col l10 s12">
@@ -64,7 +64,7 @@
       </div>
 
       {# IRC #}
-      <div id="irc-container" class="community-platform valign-table">
+      <div id="irc-container" class="community-platform valign-table resizing-container">
         <div class="row container">
           <div class="col l2 s12">
             <i class="material-icons">chat</i>

--- a/src/css/community.scss
+++ b/src/css/community.scss
@@ -21,8 +21,7 @@ main > .container {
   }
   .main {
     height: 370px;
-    background: url('../images/discord-background.svg') repeat;
-    background-color: #6881D8;
+    background: #6881D8 url('../images/discord-background.svg') repeat;
     background-size: 150px;
     display: flex;
   }
@@ -31,8 +30,7 @@ main > .container {
   width: 100%;
   padding: 5rem 0;
   height: 0px; // fix PaperMC/papermc.io#12
-  background: url('../images/forum-background.svg') repeat;
-  background-color: #E08E1D;
+  background: #E08E1D url('../images/forum-background.svg') repeat;
   background-size: 150px;
   color: white;
   
@@ -50,8 +48,7 @@ main > .container {
   width: 100%;
   padding: 5rem 0;
   height: 0px; // fix PaperMC/papermc.io#12
-  background: url('../images/guideline-background.svg') repeat;
-  background-color: #12a138;
+  background: #12a138 url('../images/guideline-background.svg') repeat;
   background-size: 150px;
   color: white;
   
@@ -69,8 +66,7 @@ main > .container {
   width: 100%;
   padding: 5rem 0;
   height: 0px;
-  background: url('../images/irc-background.svg') repeat;
-  background-color: #951717;
+  background: #951717 url('../images/irc-background.svg') repeat;
   background-size: 150px;
   color: white;
   

--- a/src/css/sponsors.scss
+++ b/src/css/sponsors.scss
@@ -13,18 +13,15 @@ i.benefit-icon {
   font-size: 8rem;
 }
 #opencollective-container {
-  background: url('../images/opencollective-background.svg') repeat;
-  background-color: #05410d;
+  background: #05410d url('../images/opencollective-background.svg') repeat;
   background-size: 150px;
 }
 #githubsponsors-container {
-  background: url('../images/githubsponsors-background.svg') repeat;
-  background-color: #1274a1;
+  background: #1274a1 url('../images/githubsponsors-background.svg') repeat;
   background-size: 150px;
 }
 #list-container {
-  background: url('../images/sponsorlist-background.svg') repeat;
-  background-color: #a18412;
+  background: #a18412 url('../images/sponsorlist-background.svg') repeat;
   background-size: 150px;
 }
 .community-platform {

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -156,8 +156,11 @@ h5 {
 h6 {
   font-size: 1rem;
 }
+.icon-container {
+  padding-left: 0 !important;
+}
 @media only screen and (max-width: 1650px) {
-  #forum-container div > i, #irc-container div > i, #guideline-container div >  i {
+  .fancy-container div > i {
     font-size: 6rem !important;
   }
 }

--- a/src/sponsors.twig
+++ b/src/sponsors.twig
@@ -12,7 +12,11 @@
     <div class="container">
       <h1>Support Us</h1>
       <p>First of all, thank you for considering helping out, we really appreciate that!</p>
-      <p>PaperMC is an open community, and part of managing the community involves paying for services, servers, and infrastructure. We do what we can to keep our costs reasonable and sustainable, but still some costs are unavoidable.</p>
+      <p>
+        PaperMC is an open community, and part of managing the community involves paying for services, servers, and
+        infrastructure. We do what we can to keep our costs reasonable and sustainable, but still some costs are
+        unavoidable.
+      </p>
       <div class="row">
         <div class="col s12 l3">
           <i class="material-icons benefit-icon">help</i>
@@ -20,9 +24,12 @@
         <div class="col s12 l9">
           <h4>Why you should donate</h4>
           <p>
-            One way to keep PaperMC sustainable is to spread the cost out across many members who choose to donate. PaperMC will always be an open community though, so all <b>donations will always be optional</b>. 
-            We will never require donations in order to gain access to anything, or require donations in order to use certain features. 
-            We also request that only those who are financially stable and able to donate to do so. You should not feel bad if you aren't able to donate, even if you want to.<br>
+            One way to keep PaperMC sustainable is to spread the cost out across many members who choose to donate.
+            PaperMC will always be an open community though, so all <b>donations will always be optional</b>. We will
+            never require donations in order to gain access to anything, or require donations in order to use certain
+            features. We also request that only those who are financially stable and able to donate to do so. You should
+            not feel bad if you aren't able to donate, even if you want to.
+            <br>
             All of our funds, expenses, and donations are visible on our Open Collective page.
           </p>
         </div>
@@ -34,7 +41,12 @@
         <div class="col s12 l9">
           <h4>Future plans</h4>
           <p>
-            Our costs are relatively low right now, and hopefully they will stay that way. However, only running a single server is not sufficient to meet our hosting needs anymore. Paper continues to grow and more and more people rely on our services and APIs to be operational. With that in mind, we currently have a project underway to determine better methods for us to host our services, with failover and redundancy built in. These changes will increase our hosting costs, which we hope to offset with our new additional donations thanks to our Open Collective and GitHub Sponsors pages.
+            Our costs are relatively low right now, and hopefully they will stay that way. However, only running a
+            single server is not sufficient to meet our hosting needs anymore. Paper continues to grow and more and more
+            people rely on our services and APIs to be operational. With that in mind, we currently have a project
+            underway to determine better methods for us to host our services, with failover and redundancy built in.
+            These changes will increase our hosting costs, which we hope to offset with our new additional donations
+            thanks to our Open Collective and GitHub Sponsors pages.
           </p>
         </div>
       </div>
@@ -45,7 +57,11 @@
         <div class="col s12 l9">
           <h4>Giving back</h4>
           <p>
-            There is also the question of contributing money back to our contributors who work very hard to continue to fix issues, implement new features, help with PRs, and all of the other work that goes into maintaining a project of this scale. If we get to a point where our monthly income from donations is much higher than our monthly costs then we can start the discussion on how we may distribute funds to contributors in a fair and transparent manner.
+            There is also the question of contributing money back to our contributors who work very hard to continue to
+            fix issues, implement new features, help with PRs, and all of the other work that goes into maintaining a
+            project of this scale. If we get to a point where our monthly income from donations is much higher than our
+            monthly costs then we can start the discussion on how we may distribute funds to contributors in a fair and
+            transparent manner.
           </p>
         </div>
       </div>
@@ -53,26 +69,33 @@
 
 	<div class="container">
 	  {# Open Collective #}
-	  <div id="opencollective-container" class="community-platform valign-table">
+	  <div id="opencollective-container" class="community-platform valign-table fancy-container">
 	    <div class="row container">
-        <div class="col l2 s12">
-		      <i class="material-icons icon-large">savings</i>
-        </div>
-        <div class="col l10 s12">
+          <div class="col l2 s12 icon-container">
+                <i class="material-icons icon-large">savings</i>
+          </div>
+          <div class="col l10 s12">
           <h1>Open Collective</h1>
-			    <p>
-            PaperMC has various recurring expenses, mostly related to infrastructure, like domains and servers. Paper uses <a href="https://opencollective.com/">Open Collective</a> via the <a href="https://opencollective.com/opensource">Open Source Collective fiscal host</a> to manage expenses.
-            Open Collective allows us to be extremely transparent, so you can always see how your donations are used. If you donate to us via Open Collective, 10% of that donation goes to our fiscal host, and around 1.5% to 3% to the payment provider.
-            <br><br>
-			      <a class="downloads-button white grey-text text-darken-4 btn nav-btn waves-effect" href="https://opencollective.com/papermc"><i class="material-icons left">archive</i>PaperMC Open Collective</a>
-			    </p>
+            <p>
+              PaperMC has various recurring expenses, mostly related to infrastructure, like domains and servers. Paper
+              uses <a href="https://opencollective.com/">Open Collective</a> via the
+              <a href="https://opencollective.com/opensource">Open Source Collective fiscal host</a> to manage expenses.
+              Open Collective allows us to be extremely transparent, so you can always see how your donations are used.
+              If you donate to us via Open Collective, 10% of that donation goes to our fiscal host, and around 1.5% to
+              3% to the payment provider.
+              <br><br>
+              <a class="downloads-button white grey-text text-darken-4 btn nav-btn waves-effect"
+                 href="https://opencollective.com/papermc">
+                <i class="material-icons left">archive</i>PaperMC Open Collective
+              </a>
+            </p>
 		  </div>
 	    </div>
 	  </div>
       {# Forum #}
-      <div id="githubsponsors-container" class="community-platform valign-table">
+      <div id="githubsponsors-container" class="community-platform valign-table fancy-container">
         <div class="row container">
-          <div class="col l2 s12">
+          <div class="col l2 s12 icon-container">
             <i class="material-icons icon-large">request_page</i>
           </div>
           <div class="col l10 s12">
@@ -86,9 +109,9 @@
         </div>
       </div>
         {# List #}
-        <div id="list-container" class="community-platform valign-table">
+        <div id="list-container" class="community-platform valign-table fancy-container">
             <div class="row container">
-                <div class="col l2 s12">
+                <div class="col l2 s12 icon-container">
                     <i class="material-icons icon-large">people</i>
                 </div>
                 <div class="col l10 s12">


### PR DESCRIPTION
This also fixes an issue with certain wide icons overlapping the text
right before the media query kicks in to re-format the contents of the
container. Simply removing the left padding fixes this, as it was
pushing the content to the right too far.