### PR TITLE
ignore duplicate names and remove GH sponsors org from json

### DIFF
--- a/.github/actions/update-sponsors/action.js
+++ b/.github/actions/update-sponsors/action.js
@@ -10,7 +10,7 @@ const root = local ? '' : '/home/runner/work/papermc.io/papermc.io/work/';
 main();
 
 async function main() {
-    let [ocData, ghData] = await Promise.all([opencollective(), github()]);
+    const [ocData, ghData] = await Promise.all([opencollective(), github()]);
 
     ocData.collective.contributors.nodes = ocData.collective.contributors.nodes
         .filter(node => node.name !== "Github Sponsors");


### PR DESCRIPTION
Removing the "github sponsors" org from the open collective data was done too late, and thus not saved in sponsors.json. Additionally, this ignores duplicate names between GH/OC.