### PR TITLE
Update website to 1.18

### DIFF
--- a/src/javadocs.twig
+++ b/src/javadocs.twig
@@ -14,9 +14,13 @@
 	  <h3>Paper</h3>
 	  <p>Javadocs for Paper can be found down below.</p>
 	  <div>
-        <a href="https://papermc.io/javadocs/paper/1.17/" class="waves-effect waves-light btn light-blue darken-2">
-                <i class="material-icons left">archive</i>1.17 javadocs</a>
-      </div>
+	    <a href="https://papermc.io/javadocs/paper/1.18/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>1.18 javadocs</a>
+	  </div>
+	  <div>
+	    <a href="https://papermc.io/javadocs/paper/1.17/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>1.17 javadocs</a>
+	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.16/" class="waves-effect waves-light btn light-blue darken-2">
               <i class="material-icons left">archive</i>1.16 javadocs</a>
@@ -41,6 +45,10 @@
 	<div id="waterfall" class="row">
 	  <h3>Waterfall</h3>
 	  <p>Javadocs for Waterfall can be found down below.</p>
+	  <div>
+	    <a href="https://papermc.io/javadocs/waterfall/1.18/" class="waves-effect waves-light btn light-blue darken-2">
+              <i class="material-icons left">archive</i>1.18 javadocs</a>
+	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/waterfall/1.17/" class="waves-effect waves-light btn light-blue darken-2">
               <i class="material-icons left">archive</i>1.17 javadocs</a>

--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -1,10 +1,19 @@
 const downloads = {
+    "Paper-1.18": {
+        "title": "Paper 1.18",
+        "api_endpoint": "paper",
+        "api_version": "1.18",
+        "github": "PaperMC/Paper",
+        "desc": "Test builds for 1.18. <b>Use with extreme caution! Backups are mandatory.</b>",
+        "limit": 10,
+        "cache": null,
+    },
     "Paper-1.17": {
         "title": "Paper 1.17.1",
         "api_endpoint": "paper",
         "api_version": "1.17",
         "github": "PaperMC/Paper",
-        "desc": "Active development for the current Minecraft version.",
+        "desc": "Support branch for 1.17.1",
         "limit": 10,
         "cache": null,
     },

--- a/src/using-the-api.twig
+++ b/src/using-the-api.twig
@@ -49,9 +49,9 @@
     compileOnly("io.papermc.paper:paper-api:<span class="latest-artifact-version"></span>")
 }</code></pre>
                 <h5>Toolchain</h3>
-                <p>Lastly, point the toolchain to Java 16:</p>
+                <p>Lastly, point the toolchain to Java 17:</p>
                 <pre><code class="kotlin">java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(16))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }</code></pre>
             </div>
         </div>


### PR DESCRIPTION
This PR
- Adds a 1.18 tab to `/downloads`
- Adds a 1.18 javadoc button to Paper and Waterfall
- Changes the toolchain instructions to Java 17