### PR TITLE
Fixes PR links on downloads 404ing

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -112,7 +112,7 @@ function load(id) {
             changes += `<span class="commit-hash">
                             [<a title="${escapeHTML(item.summary)}" href="https://github.com/${githubID}/commit/${item.commit}" target="_blank">${escapeHTML(item.commit.substring(0, 7))}</a>]
                         </span>
-                        ${escapeHTML(item.summary).replace(/([^&])#([0-9]+)/gm, `$1<a target="_blank" href="https://github.com/${githubID}/issues/$2">#$2</a>`)}
+                        ${escapeHTML(item.summary).replace(/([^&])#([0-9]+)/gm, `$1<a target="_blank" href="https://github.com/${githubID}/pull/$2">#$2</a>`)}
                         <br>`;
         });
 


### PR DESCRIPTION
Untested and webedited because I dont have a devenv on hand, and I am patching log4J instances.

Currently, the PR links on downloads point to GitHub issues
![image](https://user-images.githubusercontent.com/25063394/145544713-cd51f956-4ed1-4737-8429-b9016544c60e.png)

This used to work, however, it doesn't anymore.
![image](https://user-images.githubusercontent.com/25063394/145544759-6c5bb799-bdcf-4275-8eb9-5e8d27165c65.png)
