### PR TITLE
Removing Legacy downloads due to RCE exploit.

### DIFF
--- a/src/js/legacy.js
+++ b/src/js/legacy.js
@@ -7,39 +7,41 @@ const downloads = {
         {
           "version": "1.16.5",
           "build": "792"
-        },
-        {
-          "version": "1.15.2",
-          "build": "391"
-        },
-        {
-          "version": "1.14.4",
-          "build": "243"
-        },
-        {
-          "version": "1.13.2",
-          "build": "655"
-        },
-        {
-          "version": "1.12.2",
-          "build": "1618"
-        },
-        {
-          "version": "1.11.2",
-          "build": "1104"
-        },
-        {
-          "version": "1.10.2",
-          "build": "916"
-        },
-        {
-          "version": "1.9.4",
-          "build": "773"
-        },
-        {
-          "version": "1.8.8",
-          "build": "443"
         }
+        // Legacy downloads removed due to RCE exploit: CVE-2021-44228 
+        //,
+        // {
+        //   "version": "1.15.2",
+        //   "build": "391"
+        // },
+        // {
+        //   "version": "1.14.4",
+        //   "build": "243"
+        // },
+        // {
+        //   "version": "1.13.2",
+        //   "build": "655"
+        // },
+        // {
+        //   "version": "1.12.2",
+        //   "build": "1618"
+        // },
+        // {
+        //   "version": "1.11.2",
+        //   "build": "1104"
+        // },
+        // {
+        //   "version": "1.10.2",
+        //   "build": "916"
+        // },
+        // {
+        //   "version": "1.9.4",
+        //   "build": "773"
+        // },
+        // {
+        //   "version": "1.8.8",
+        //   "build": "443"
+        // }
       ],
       cache: null
   },


### PR DESCRIPTION
This comments out the pre-1.16.5 downloads to prevent users downloading older Paper versions which contain an RCE exploit.