### PR TITLE
Use current year for copyright year

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,8 @@ gulp.task('content', () => {
     let busters = JSON.parse(fs.readFileSync('dist/busters.json'));
 
     var twigData = {
-      urls: {}
+      urls: {},
+      year: new Date().getFullYear()
     };
 
     Object.keys(busters).forEach(file => {

--- a/src/partial/layout.twig
+++ b/src/partial/layout.twig
@@ -127,7 +127,7 @@
         <div class="container">
           <div class="row">
             <div class="col s12 m6 left-align">
-              <span class="copyright">&copy; 2021 The PaperMC Team</span>
+              <span class="copyright">&copy; {{ year }} The PaperMC Team</span>
             </div>
             <div class="col s12 m6 right-align">
               <a class="white-text waves-effect" href="https://discord.gg/papermc">


### PR DESCRIPTION
Uses the current year (when building the site) for the copyright notice in the site footer.

Also indirectly updates the year to 2022, happy new year! 🥳 