### PR TITLE
Add link to Minecraft version post from legacy page

### DIFF
--- a/src/legacy.twig
+++ b/src/legacy.twig
@@ -25,7 +25,7 @@
       </li>
       <li>
         <i class="tiny material-icons">error</i>
-          <a href="https://madelinemiller.dev/blog/which-minecraft-version/" target="_blank" rel="noopener noreferrer">You likely don't want to use them</a>.
+          You likely don't want to use them. (<a href="https://madelinemiller.dev/blog/which-minecraft-version/" target="_blank" rel="noopener noreferrer">Read more</a>)
       </li>
     </ul>
 

--- a/src/legacy.twig
+++ b/src/legacy.twig
@@ -23,6 +23,10 @@
         <i class="tiny material-icons">error</i>
           You may be kicked when asking for support on our Discord.
       </li>
+      <li>
+        <i class="tiny material-icons">error</i>
+          <a href="https://madelinemiller.dev/blog/which-minecraft-version/" target="_blank" rel="noopener noreferrer">You likely don't want to use them</a>.
+      </li>
     </ul>
 
     <div class="row" id="quiz">


### PR DESCRIPTION
Links to my page explaining various reasons why someone shouldn't use an old version, with text stating "You likely don't want to use them" to help dissuade it