### PR TITLE
Make javadoc icons match the header dropdown

### DIFF
--- a/src/index.twig
+++ b/src/index.twig
@@ -54,7 +54,7 @@
           <a href="using-the-api" class="waves-effect waves-light btn light-blue darken-2 use-api-button">
             <i class="material-icons left">archive</i>Use our API</a>
           <a href="javadocs" class="waves-effect waves-light btn light-blue darken-2">
-            <i class="material-icons left">archive</i>Learn about our API</a>
+            <i class="material-icons left">integration_instructions</i>Learn about our API</a>
         </div>
       </div>
       <div class="row">

--- a/src/javadocs.twig
+++ b/src/javadocs.twig
@@ -15,31 +15,31 @@
 	  <p>Javadocs for Paper can be found down below.</p>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.18/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.18 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.18 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.17/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.17 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.17 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.16/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.16 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.16 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.15/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.15 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.15 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.14/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.14 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.14 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.13/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.13 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.13 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/paper/1.12/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.12 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.12 javadocs</a>
       </div>
 	</div>
 	<div id="waterfall" class="row">
@@ -47,15 +47,15 @@
 	  <p>Javadocs for Waterfall can be found down below.</p>
 	  <div>
 	    <a href="https://papermc.io/javadocs/waterfall/1.18/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.18 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.18 javadocs</a>
 	  </div>
 	  <div>
 	    <a href="https://papermc.io/javadocs/waterfall/1.17/" class="waves-effect waves-light btn light-blue darken-2">
-              <i class="material-icons left">archive</i>1.17 javadocs</a>
+              <i class="material-icons left">integration_instructions</i>1.17 javadocs</a>
 	  </div>
 	  <div>
         <a href="https://papermc.io/javadocs/waterfall/1.16/" class="waves-effect waves-light btn light-blue darken-2">
-                <i class="material-icons left">archive</i>1.16 javadocs</a>
+                <i class="material-icons left">integration_instructions</i>1.16 javadocs</a>
       </div>
 	</div>
   </main>


### PR DESCRIPTION
The previous javadoc icons make it look like you are about to download them