### PR TITLE
1.19 paper and only show API vers with builds

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -8,6 +8,15 @@ const downloads = {
         "limit": 10,
         "cache": null,
     },
+    "Paper-1.19": {
+        "title": "Paper 1.19",
+        "api_endpoint": "paper",
+        "api_version": "1.19",
+        "github": "PaperMC/Paper",
+        "desc": "Early development for Minecraft 1.19",
+        "limit": 10,
+        "cache": null,
+    },
     "Velocity": {
         "title": "Velocity",
         "api_endpoint": "velocity",

--- a/src/js/using-the-api.js
+++ b/src/js/using-the-api.js
@@ -4,14 +4,25 @@ async function fetchLatestArtifactVersion() {
         return null;
 
     const versionGroups = rootResponse.version_groups;
-    const latestVersionGroup = versionGroups[versionGroups.length - 1];
+    versionGroups.reverse()
+    console.log(versionGroups)
+    let latestVersion = "Unknown";
+    for (const id of versionGroups) {
+        const versionGroupResponse = await fetchUrl(`https://papermc.io/api/v2/projects/paper/version_group/${id}/`)
+        const versions = versionGroupResponse.versions
+        if (versions === null || versions.length === 0) {
+            continue
+        }
 
-    const versionGroupResponse = await fetchUrl(`https://api.papermc.io/v2/projects/paper/version_group/${latestVersionGroup}/`);
-    if (versionGroupResponse === null)
-        return null;
+        const versionInfo = await fetchUrl(`https://papermc.io/api/v2/projects/paper/versions/${versions[versions.length-1]}`)
+        console.log(versionInfo)
+        if (versionInfo === null || versionInfo.builds === null || versionInfo.builds.length === 0) {
+            continue
+        }
+        latestVersion = versions[versions.length-1]
+        break;
 
-    const versions = versionGroupResponse.versions;
-    const latestVersion = versions[versions.length - 1];
+    }
 
     return `${latestVersion}-R0.1-SNAPSHOT`;
 }


### PR DESCRIPTION
JS is not a strong point for me here, but, successfully fetches
only the latest version with actual builds for the API page

Fixes #176