### PR TITLE
add player safety bypass rule

### DIFF
--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -163,7 +163,7 @@
               </li>
             </ol>
           </li>
-          <li>Discussing the bypassing of Minecraft's player safety features in a malicious or otherwise ill-meaning way. This applies to discussion around how to bypass chat reporting specifically, as well as any other features that make Minecraft a safer place for its users.
+          <li>Discussing the bypassing or exploiting of Minecraft's player safety features in any way that is malicious or harmful. This applies to discussion around how to bypass chat reporting specifically, as well as any other features that make Minecraft a safer place for its users.
             <ol type="a">
               <li>
                 This does not apply to general discussion of the safety features themselves, nor does it apply to discussion of these features' potential downsides. Further we will not forbid general discussion of 'proper' ways to disable safety features for legitimate reasons. Only those meaning to bypass them for the sake of avoiding accountability or otherwise being malicious will be punished.

--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -163,10 +163,10 @@
               </li>
             </ol>
           </li>
-          <li>Discussing the bypassing of Minecraft's player safety features. This applies to discussion around how to bypass chat reporting specifically, as well as any other features that make Minecraft a safer place for its users.
+          <li>Discussing the bypassing of Minecraft's player safety features in a malicious or otherwise ill-meaning way. This applies to discussion around how to bypass chat reporting specifically, as well as any other features that make Minecraft a safer place for its users.
             <ol type="a">
               <li>
-                This does not apply to general discussion of the safety features themselves, nor does it apply to discussion of these features' potential downsides.
+                This does not apply to general discussion of the safety features themselves, nor does it apply to discussion of these features' potential downsides. Further we will not forbid general discussion of 'proper' ways to disable safety features for legitimate reasons. Only those meaning to bypass them for the sake of avoiding accountability or otherwise being malicious will be punished.
               </li>
             </ol>
           </li>

--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -163,6 +163,13 @@
               </li>
             </ol>
           </li>
+          <li>Discussing the bypassing of Minecraft's player safety features. This applies to discussion around how to bypass chat reporting specifically, as well as any other features that make Minecraft a safer place for its users.
+            <ol type="a">
+              <li>
+                This does not apply to general discussion of the safety features themselves, nor does it apply to discussion of these features' potential downsides.
+              </li>
+            </ol>
+          </li>
         </ol>
         <p>
           If someone is violating those feel free to use the <code>@mods</code> ping on Discord to notify the moderation team.


### PR DESCRIPTION
As agreed upon by the vast majority of the Paper team, this rule is added to forbid some discussion of how to bypass player safety features such as chat reporting. As always, actually doing it will still be possible with Paper, but like with offline mode, it won't be supported.