### PR TITLE
add the no politics rule

### DIFF
--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -156,10 +156,10 @@
               <li>There are some users who don't want to be pinged, so please respect their decision.</li>
             </ol>
           </li>
-          <li>Discussing politics or political controversy. We prohibit this in order to prevent he degeneration of our chat channels.
+          <li>Discussing politics or political controversy. We prohibit this in order to prevent the degeneration of our chat channels.
             <ol type="a">
               <li>
-                This does not apply to instances where people are speaking about their everyday lives - only when discussion devolves to the point of being solely about some political scandal or controversy.
+                This does not apply to instances where people are speaking about their everyday lives or current events - only when discussion devolves to the point of being solely about some political scandal or controversy.
               </li>
             </ol>
           </li>

--- a/src/community-guidelines.twig
+++ b/src/community-guidelines.twig
@@ -156,6 +156,13 @@
               <li>There are some users who don't want to be pinged, so please respect their decision.</li>
             </ol>
           </li>
+          <li>Discussing politics or political controversy. We prohibit this in order to prevent he degeneration of our chat channels.
+            <ol type="a">
+              <li>
+                This does not apply to instances where people are speaking about their everyday lives - only when discussion devolves to the point of being solely about some political scandal or controversy.
+              </li>
+            </ol>
+          </li>
           <li>Discussing piracy or pirated software. This explicitly applies to "offline-mode" (not authenticating users against Mojang) as well.
             <ol type="a">
               <li>


### PR DESCRIPTION
This covers the sentiment of the moderation team that was announced some time ago. It should specifically allow people to talk about their lives, but not to allow conversation to devolve dramatically to the point where mods need to get involved.