### PR TITLE
Use local timezone for build date

### DIFF
--- a/src/js/downloads.js
+++ b/src/js/downloads.js
@@ -139,7 +139,7 @@ function load(id) {
                             ${changes}
                         </td>
                         <td>
-                            ${new Date(build.time).toISOString().split('T')[0]}
+                            ${new Date(build.time).toLocaleDateString('en-CA')}
                         </td>
                         <td>
                             <a class="downloads-button white grey-text text-darken-4 btn nav-btn waves-effect" onclick="copy('${build.downloads.application.sha256}')" title="Click to copy the SHA256 of the jar, used to verify the integrity">


### PR DESCRIPTION
Title. `Date#toISOString` converts to UTC, which can cause confusion in cases where it's ahead of users, allowing for scenarios where a build was created 'tomorrow'. The `en-CA` locale formats dates in the exact same way the site shows them now (`YYYY-MM-DD`), just without the conversion to UTC.