### PR TITLE
[ci skip] Update depencies for workflow

### DIFF
--- a/.github/actions/update-sponsors/action.yml
+++ b/.github/actions/update-sponsors/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: node12
+  using: node16
   main: action.js

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
       - name: Checkout data branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5.0
         with:
           ref: data
           path: work
@@ -22,7 +22,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9.1.1
         with:
           add: .
           author_name: Automated


### PR DESCRIPTION
This PR only update the version based in the warnings for deprecation like the uses of node12 and the enviroment set/get.

i cant test the workflow because the custom action created use the organization things and fail for oauth.