### PR TITLE
removed unnecessary complexity in repo definition

### DIFF
--- a/src/using-the-api.twig
+++ b/src/using-the-api.twig
@@ -50,7 +50,7 @@
                 <h5>Repository</h5>
                 <p>Add this to your <code>build.gradle.kts</code>:</p>
                 <pre><code class="kotlin">repositories {
-    maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
+    maven("https://repo.papermc.io/repository/maven-public/")
 }</code></pre>
 
                 <h5>Dependency</h5>


### PR DESCRIPTION
changed using-the-api to use 
`maven("https://repo.papermc.io/repository/maven-public/")` 
instead of 
`maven { url = uri("https://repo.papermc.io/repository/maven-public/") }`